### PR TITLE
'CartridgeController' removes 'Platform'; returns 'Result'

### DIFF
--- a/CartBoy/CartBoy/App/ContentViewController.swift
+++ b/CartBoy/CartBoy/App/ContentViewController.swift
@@ -10,13 +10,13 @@ class ContentViewController: ContextViewController {
     @IBOutlet weak var statusView: NSView!
 
     @IBAction func read(_ sender: Any?) {
-        self.context.perform {
-            let result = Result<GameboyClassic.Cartridge, Error> {
-                let controller = try insideGadgetsController<GameboyClassic>()
-                return try await { controller.readCartridge(progress: { self.context.update(progressBar: self.readProgressBar, with: $0) }, $0) }
-            }
-            
-            switch result {
+        insideGadgetsController.perform { controller in
+            switch controller.flatMap({
+                $0.cartridge(for: GameboyClassic.self, progress: {
+                    self.context.update(progressBar: self.readProgressBar, with: $0)
+                })
+            })
+            {
             case .success(let cartridge):
                 DispatchQueue.main.sync {
                     let savePanel = NSSavePanel()
@@ -48,38 +48,34 @@ class ContentViewController: ContextViewController {
             }
             
             let flashCartridge = AM29F016B(bytes: data)
-            
-            self.context.perform {
-                let result = Result<(), Error> {
-                    let controller = try insideGadgetsController<GameboyClassic>()
-                    DispatchQueue.main.sync {
-                        self.statusView.isHidden = false
-                        self.statusTextField.stringValue = "Erasing..."
-                        self.spinnerProgressBar.isHidden = false
-                        self.spinnerProgressBar.startAnimation(sender)
-                    }
-                    let _ /*write*/= try await { controller.write(flashCartridge, progress: { value in
+            insideGadgetsController.perform { controller in
+                DispatchQueue.main.sync {
+                    self.statusView.isHidden = false
+                    self.statusTextField.stringValue = "Erasing..."
+                    self.spinnerProgressBar.isHidden = false
+                    self.spinnerProgressBar.startAnimation(sender)
+                }
+                switch controller.flatMap({ controller in
+                    controller.write(to: flashCartridge, progress: { amount in
                         if self.statusTextField.stringValue != "Flashing..." {
                             self.statusTextField.stringValue = "Flashing..."
                             self.spinnerProgressBar.isHidden = true
                             self.spinnerProgressBar.stopAnimation(sender)
                         }
-                        self.context.update(progressBar: self.writeProgressBar, with: value)
-                    }, $0) }
-                    DispatchQueue.main.sync {
-                        self.statusView.isHidden = true
-                    }
-                    if let appDelegate = NSApp.delegate as? AppDelegate, let cartInfo = appDelegate.cartInfoController {
-                        cartInfo.readHeader(sender)
-                    }
-                    return ()
-                }
-
-                switch result {
+                        self.context.update(progressBar: self.writeProgressBar, with: amount)
+                    })
+                }) {
                 case .success: ()
                 case .failure(let error):
-                    print(error)
                     self.context.display(error: error, in: self)
+                }
+                //--------------------------------------------------------------
+                // Double-check these two 'finality' logic blocks...
+                DispatchQueue.main.sync {
+                    self.statusView.isHidden = true
+                }
+                if let appDelegate = NSApp.delegate as? AppDelegate, let cartInfo = appDelegate.cartInfoController {
+                    cartInfo.readHeader(sender)
                 }
             }
         }

--- a/CartBoy/CartBoy/App/ProductInfoViewController.swift
+++ b/CartBoy/CartBoy/App/ProductInfoViewController.swift
@@ -33,12 +33,11 @@ class ProductInfoViewController: ContextViewController {
     }
     
     @IBAction func readProductInfo(_ sender: Any?) {
-        self.context.perform {
-            let result = Result { try insideGadgetsController<GameboyClassic>() }
-                .flatMap { controller in Result { try await { controller.currentVoltage($0) } } }
-                .flatMap { self.updateProductInfoResult(voltage: $0.rawValue, website: "www.insideGadgets.com") }
-
-            switch result {
+        insideGadgetsController.perform { controller in
+            switch controller
+                .flatMap({ controller in .success(Voltage.high) /* controller.voltage() */ })
+                .flatMap({ self.updateProductInfoResult(voltage: $0.rawValue, website: "www.insideGadgets.com") })
+            {
             case .success: ()
             case .failure(let error):
                 self.context.display(error: error, in: self)

--- a/CartBoy/CartBoyTests/CartBoyTests.swift
+++ b/CartBoy/CartBoyTests/CartBoyTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import CartBoy
+import CartKit
 
 class CartBoyTests: XCTestCase {
 

--- a/CartKit/CartKit.xcodeproj/project.pbxproj
+++ b/CartKit/CartKit.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 		0AC92F8A21F95FD100605C82 /* ORSSerial.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AAD80EF21F380F900D548C8 /* ORSSerial.framework */; };
 		0ADD78A2227E8AC200C93667 /* CartridgeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADD78A1227E8AC200C93667 /* CartridgeController.swift */; };
 		0ADD78A8227F76BC00C93667 /* insideGadgetsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADD78A7227F76BC00C93667 /* insideGadgetsController.swift */; };
-		0ADD78AA227F76CA00C93667 /* insideGadgetsMiniController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADD78A9227F76CA00C93667 /* insideGadgetsMiniController.swift */; };
 		0ADE2865224846FE00BD4E6A /* AM29F016B.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADE2860224846FE00BD4E6A /* AM29F016B.swift */; };
 		0AE7F270221D942A00D86827 /* NSCondition+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE7F26F221D942A00D86827 /* NSCondition+Ext.swift */; };
 /* End PBXBuildFile section */
@@ -79,7 +78,6 @@
 		0AC92F7F21F95F8D00605C82 /* Gibby.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Gibby.xcodeproj; path = ../Dependencies/Gibby/Gibby.xcodeproj; sourceTree = "<group>"; };
 		0ADD78A1227E8AC200C93667 /* CartridgeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartridgeController.swift; sourceTree = "<group>"; };
 		0ADD78A7227F76BC00C93667 /* insideGadgetsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = insideGadgetsController.swift; sourceTree = "<group>"; };
-		0ADD78A9227F76CA00C93667 /* insideGadgetsMiniController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = insideGadgetsMiniController.swift; sourceTree = "<group>"; };
 		0ADE2860224846FE00BD4E6A /* AM29F016B.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AM29F016B.swift; sourceTree = "<group>"; };
 		0AE7F26F221D942A00D86827 /* NSCondition+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSCondition+Ext.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -161,7 +159,6 @@
 			isa = PBXGroup;
 			children = (
 				0ADD78A7227F76BC00C93667 /* insideGadgetsController.swift */,
-				0ADD78A9227F76CA00C93667 /* insideGadgetsMiniController.swift */,
 			);
 			path = insideGadgets;
 			sourceTree = "<group>";
@@ -407,7 +404,6 @@
 				0ADD78A2227E8AC200C93667 /* CartridgeController.swift in Sources */,
 				0A11DB6222127E1600C7DD13 /* Data+Ext.swift in Sources */,
 				0A11E6E9224423C2007F60E3 /* Voltage.swift in Sources */,
-				0ADD78AA227F76CA00C93667 /* insideGadgetsMiniController.swift in Sources */,
 				0A973E78225A72AD000D3555 /* Await.swift in Sources */,
 				0AE7F270221D942A00D86827 /* NSCondition+Ext.swift in Sources */,
 				0A67DE6521F4CCC0009CA98F /* ORSSerialPort+Ext.swift in Sources */,

--- a/CartKit/Source/Devices/insideGadgets/insideGadgetsController.swift
+++ b/CartKit/Source/Devices/insideGadgets/insideGadgetsController.swift
@@ -1,151 +1,135 @@
 import ORSSerial
 import Gibby
 
-public class insideGadgetsController<Platform: Gibby.Platform>: ThreadSafeSerialPortController, CartridgeController {
-    /**
-     */
-    public override init(matching portProfile: ORSSerialPortManager.PortProfile = .usb(vendorID: 6790, productID: 29987)) throws {
+//MARK: - insideGadgetsController (Class) -
+public final class insideGadgetsController: ThreadSafeSerialPortController {
+    override init(matching portProfile: ORSSerialPortManager.PortProfile = .usb(vendorID: 6790, productID: 29987)) throws {
         try super.init(matching: portProfile)
     }
     
-    /// The operation queue to submit _requests_ on.
-    ///
-    /// - warning:
-    /// Upon starting requests, the calling thread gets blocked until a response
-    /// can materialize. However, `SerialPortRequest` is to receive serial port
-    /// delegate callbacks on the main thread, so if the thread that starts the
-    /// request is also the main thread **a deadlock is guaranteed to occur**.
-    fileprivate let queue = OperationQueue()
-
-    /**
-     Opens the serial port.
-     
-     In addition to being opened, the serial port is explicitly configured as
-     if it were device manufactured by insideGadgets.com before returning.
-     
-     - Returns: An open serial port.
-     */
     public override func open() -> ORSSerialPort {
         return super.open().configuredAsGBxCart()
     }
-
-    /**
-     */
-    private func determineVoltageResult() -> Result<Voltage, Error> {
-        return .success(.high)
-        // return self
-        //     .sendAndWait({
-        //         self.stop(timeout: 250)
-        //         self.send("C\0".bytes())
-        //     })
-        //     .flatMap {
-        //         guard let voltage = Voltage($0.first ?? .min) else {
-        //             return .failure(VoltageError.invalidVoltage)
-        //         }
-        //         return .success(voltage)
-        // }
-    }
     
-    /**
-     */
-    public func currentVoltage(_ result: @escaping (Result<Voltage, Error>) -> ()) {
-        self.queue.addOperation(BlockOperation {
-            result(self.determineVoltageResult())
-        })
-    }
-    
-    /**
-     */
-    public func voltageMatchesPlatform(_ result: @escaping (Result<(), Error>) -> ()) {
-        self.queue.addOperation(BlockOperation {
-            result(self
-                .determineVoltageResult()
-                .flatMap {
-                    switch (Platform.self, $0) {
-                    case (is GameboyClassic.Type, .high): return .success(())
-                    case (is GameboyAdvance.Type, .low): return .success(())
-                    default: return .failure(VoltageCheckError.voltageMismatch(expected: Platform.self))
-                    }
+    public func voltage() -> Result<Voltage, Error> {
+        precondition(Thread.current != .main)
+        return Result {
+            try await {
+                self.request(totalBytes: 1
+                    , packetSize: 1
+                    , prepare: { _ in
+                        self.send("C\0".bytes())
                 }
-            )
-        })
-    }
-    
-    /**
-     */
-    public func voltageMatches<FlashCartridge: CartKit.FlashCartridge>(_ flashCartridge: FlashCartridge, _ result: @escaping (Result<(), Error>) -> ()) {
-        self.queue.addOperation(BlockOperation {
-            result(self
-                .determineVoltageResult()
-                .flatMap {
-                    guard flashCartridge.voltage == $0 else {
-                        return .failure(VoltageCheckError.voltageMismatch(expected: Platform.self))
-                    }
-                    return .success(())
+                    , progress: { _, _ in }
+                    , responseEvaluator: { _ in true }
+                    , result: $0)
+                    .start()
+            }
+            }
+            .flatMap {
+                guard let voltage = Voltage($0.first ?? .min) else {
+                    return .failure(VoltageError.invalidVoltage)
                 }
-            )
-        })
+                return .success(voltage)
+        }
     }
 }
 
-extension insideGadgetsController {
-    @discardableResult
-    private func `continue`() -> Bool {
-        return send("1".bytes())
-    }
-    
-    @discardableResult
-    private func stop(timeout: UInt32 = 0) -> Bool {
-        return send("0".bytes(), timeout: timeout)
-    }
-    
-    @discardableResult
-    private func read() -> Bool {
-        switch Platform.self {
-        case is GameboyClassic.Type: return send("R".bytes())
-        case is GameboyAdvance.Type: return send("r".bytes())
-        default: return false
+//MARK: - insideGadgetsController (CatridgeController) -
+extension insideGadgetsController: CartridgeController {
+    public static func perform(on queue: DispatchQueue = DispatchQueue(label: ""), _ block: @escaping (Result<insideGadgetsController, Error>) -> ()) {
+        queue.async {
+            block(Result { try .init() })
         }
     }
     
-    @discardableResult
-    private func go(to address: Platform.AddressSpace, timeout: UInt32 = 250) -> Bool {
-        return send("A", number: address, timeout: timeout)
-    }
-    
-    /**
-     */
-    private func headerResult() -> Result<Platform.Header, Error> {
-        return self.read(byteCount: Platform.headerRange.count
-            , startingAt: Platform.headerRange.lowerBound
-            , prepare: {
-                switch Platform.self {
-                case is GameboyClassic.Type: (self as! insideGadgetsController<GameboyClassic>).toggleRAM(on: false)
-                case is GameboyAdvance.Type: ()
-                default: (/* TODO: INVALID PLATFORM ERROR */)
-                }
-            })
+    public func header<Platform: Gibby.Platform>(for platform: Platform.Type) -> Result<Platform.Header, Error> {
+        return self
+            .verify(platform: platform)
+            .flatMap {
+                self.read(platform: $0
+                    , byteCount: Platform.headerRange.count
+                    , startingAt: Platform.headerRange.lowerBound
+                    , prepare: {
+                        switch platform {
+                        case is GameboyClassic.Type: self.toggleRAM(on: true)
+                        default: (/* no-op */)
+                        }
+                })
+            }
             .flatMap { data in
-                let header = Platform.Header(bytes: data)
+                let header = platform.Header(bytes: data)
                 guard header.isLogoValid else {
                     return .failure(CartridgeControllerError<Platform>.invalidHeader)
                 }
                 return .success(header)
+        }
+    }
+    
+    public func cartridge<Platform: Gibby.Platform>(for platform: Platform.Type, progress update: @escaping (Double) -> ()) -> Result<Platform.Cartridge, Error> {
+        return .failure(CartridgeControllerError.platformNotSupported(platform))
+    }
+    
+    public func cartridge(for platform: GameboyClassic.Type, progress update: @escaping (Double) -> ()) -> Result<GameboyClassic.Cartridge, Error> {
+        return self
+            .header(for: platform)
+            .map { ($0, Progress(totalUnitCount: Int64($0.romSize))) }
+            .flatMap { (header, progress) in
+                //--------------------------------------------------------------
+                let observer = progress.observe(\.fractionCompleted, options: [.new]) { _, change in
+                    DispatchQueue.main.async {
+                        update(change.newValue ?? 0)
+                    }
+                }
+                //--------------------------------------------------------------
+                defer { observer.invalidate() }
+                //--------------------------------------------------------------
+                return Result {
+                    var romData = Data()
+                    for bank in 0..<header.romBanks {
+                        progress.becomeCurrent(withPendingUnitCount: Int64(header.romBankSize))
+                        //--------------------------------------------------------------
+                        let bankData = try self.read(platform: GameboyClassic.self
+                            , byteCount: header.romBankSize
+                            , startingAt: bank > 0 ? 0x4000 : 0x0000
+                            , prepare: {
+                                self.mbc2(fix: header)
+                                //------------------------------------------------------
+                                guard bank > 0 else { return }
+                                //------------------------------------------------------
+                                if case .one = header.configuration {
+                                    self.set(bank:           0, at: 0x6000)
+                                    self.set(bank:   bank >> 5, at: 0x4000)
+                                    self.set(bank: bank & 0x1F, at: 0x2000)
+                                }
+                                else {
+                                    self.set(bank: bank, at: 0x2100)
+                                    if bank > 0x100 {
+                                        self.set(bank: 1, at: 0x3000)
+                                    }
+                                }
+                        }).get()
+                        //--------------------------------------------------------------
+                        romData.append(bankData)
+                        //--------------------------------------------------------------
+                        progress.resignCurrent()
+                    }
+                    return romData
+                }
             }
+            .map { .init(bytes: $0) }
     }
     
-    private func cartridgeResult(_ update: @escaping ProgressCallback) -> Result<Platform.Cartridge, Error> {
+    public func backupSave<Platform: Gibby.Platform>(for platform: Platform.Type, progress: @escaping (Double) -> ()) -> Result<Data, Error> {
+        return .failure(CartridgeControllerError.platformNotSupported(platform))
+    }
+    
+    public func backupSave(for platform: GameboyClassic.Type, progress update: @escaping (Double) -> ()) -> Result<Data, Error> {
         return self
-            .headerResult()
-            .flatMap { header in
-                var progress: Progress!
+            .header(for: platform)
+            .map { ($0, Progress(totalUnitCount: Int64($0.ramSize))) }
+            .flatMap { (header, progress) in
                 //--------------------------------------------------------------
-                switch Platform.self {
-                case is GameboyClassic.Type: progress = Progress(totalUnitCount: Int64((header as! GameboyClassic.Header).romSize))
-                case is GameboyAdvance.Type: progress = Progress(totalUnitCount: Int64((self as! insideGadgetsController<GameboyAdvance>).romSize()))
-                default:
-                    return .failure(CartridgeControllerError.platformNotSupported(Platform.self))
-                }
                 let observer = progress.observe(\.fractionCompleted, options: [.new]) { _, change in
                     DispatchQueue.main.sync {
                         update(change.newValue ?? 0)
@@ -154,29 +138,48 @@ extension insideGadgetsController {
                 //--------------------------------------------------------------
                 defer { observer.invalidate() }
                 //--------------------------------------------------------------
-                switch Platform.self {
-                case is GameboyClassic.Type:
-                    return (self as! insideGadgetsController<GameboyClassic>)
-                        .romDataResult(updating: progress, header: header as! GameboyClassic.Header)
-                        .map { .init(bytes: $0) }
-                default:
-                    return .failure(CartridgeControllerError.platformNotSupported(Platform.self))
+                return Result {
+                    let ramBankSize = Int64(header.ramBankSize)
+                    var backupData = Data()
+                    for bank in 0..<header.ramBanks {
+                        //------------------------------------------------------
+                        progress.becomeCurrent(withPendingUnitCount: ramBankSize)
+                        //------------------------------------------------------
+                        let bankData = try self.read(platform: platform
+                            , byteCount: ramBankSize
+                            , startingAt: 0xA000
+                            , prepare: {
+                                self.mbc2(fix: header)
+                                //----------------------------------------------
+                                // SET: the 'RAM' mode (MBC1-ONLY)
+                                //----------------------------------------------
+                                if case .one = header.configuration {
+                                    self.set(bank: 1, at: 0x6000)
+                                }
+                                //----------------------------------------------
+                                self.toggleRAM(on: true)
+                                self.set(bank: bank, at: 0x4000)
+                        }).get()
+                        //------------------------------------------------------
+                        backupData.append(bankData)
+                        //------------------------------------------------------
+                        progress.resignCurrent()
+                    }
+                    return backupData
                 }
         }
     }
     
-    private func backupResult(_ update: @escaping ProgressCallback) -> Result<Data, Error> {
+    public func restoreSave<Platform: Gibby.Platform>(for platform: Platform.Type, data: Data, progress: @escaping (Double) -> ()) -> Result<(), Error> {
+        return .failure(CartridgeControllerError.platformNotSupported(platform))
+    }
+    
+    public func restoreSave(for platform: GameboyClassic.Type, data: Data, progress update: @escaping (Double) -> ()) -> Result<(), Error> {
         return self
-            .headerResult()
-            .flatMap { header in
-                var progress: Progress!
+            .header(for: platform)
+            .map { ($0, Progress(totalUnitCount: Int64($0.ramSize))) }
+            .flatMap { (header, progress) in
                 //--------------------------------------------------------------
-                switch Platform.self {
-                case is GameboyClassic.Type: progress = Progress(totalUnitCount: Int64((header as! GameboyClassic.Header).ramSize))
-                case is GameboyAdvance.Type: progress = Progress(totalUnitCount: Int64((self as! insideGadgetsController<GameboyAdvance>).ramSize()))
-                default:
-                    return .failure(CartridgeControllerError.platformNotSupported(Platform.self))
-                }
                 let observer = progress.observe(\.fractionCompleted, options: [.new]) { _, change in
                     DispatchQueue.main.sync {
                         update(change.newValue ?? 0)
@@ -185,28 +188,98 @@ extension insideGadgetsController {
                 //--------------------------------------------------------------
                 defer { observer.invalidate() }
                 //--------------------------------------------------------------
-                switch Platform.self {
-                case is GameboyClassic.Type:
-                    return (self as! insideGadgetsController<GameboyClassic>)
-                        .ramDataResult(updating: progress, header: header as! GameboyClassic.Header)
-                default:
-                    return .failure(CartridgeControllerError.platformNotSupported(Platform.self))
+                return Result {
+                    for bank in 0..<header.ramBanks {
+                        let startIndex = bank * header.ramBankSize
+                        let endIndex   = startIndex.advanced(by: header.ramBankSize)
+                        //--------------------------------------------------------------
+                        let slice  = data[startIndex..<endIndex]
+                        let ramBankSize = Int64(slice.count)
+                        //--------------------------------------------------------------
+                        progress.becomeCurrent(withPendingUnitCount: ramBankSize)
+                        //--------------------------------------------------------------
+                        _ = try await {
+                            self.request(totalBytes: ramBankSize / 64
+                                , packetSize: 1
+                                , prepare: { _ in
+                                    if bank == 0 { self.toggleRAM(on: true) }
+                                    //--------------------------------------------------
+                                    self.stop()
+                                    self.mbc2(fix: header)
+                                    //--------------------------------------------------
+                                    // SET: the 'RAM' mode (MBC1-ONLY)
+                                    //--------------------------------------------------
+                                    if case .one = header.configuration {
+                                        self.set(bank: 1, at: 0x6000)
+                                    }
+                                    //--------------------------------------------------
+                                    self.set(bank: bank, at: 0x4000)
+                                    self.go(to: 0xA000)
+                                    self.send(saveData: slice[slice.startIndex..<slice.startIndex.advanced(by: 64)])
+                            }
+                                , progress: { _, progress in
+                                    let startAddress = Int(progress.completedUnitCount * 64).advanced(by: slice.startIndex)
+                                    let rangeOfBytes = startAddress..<Int(startAddress + 64)
+                                    self.send(saveData: slice[rangeOfBytes])
+                            }
+                                , responseEvaluator: { _ in true }
+                                , result: $0)
+                                .start()
+                        }
+                        //--------------------------------------------------------------
+                        progress.resignCurrent()
+                    }
                 }
         }
+    }
+    
+    public func deleteSave<Platform: Gibby.Platform>(for platform: Platform.Type, progress: @escaping (Double) -> ()) -> Result<(), Error> {
+        return .failure(CartridgeControllerError.platformNotSupported(platform))
+    }
+    
+    public func deleteSave(for platform: GameboyClassic.Type, progress updating: @escaping (Double) -> ()) -> Result<(), Error> {
+        return self
+            .header(for: platform)
+            .flatMap { self.restoreSave(for: platform, data: Data(count: $0.ramSize), progress: updating) }
+    }
+    
+    public func erase<FlashCartridge: CartKit.FlashCartridge>(chipset: FlashCartridge.Type) -> Result<(), Error> {
+        return .failure(CartridgeFlashError.unsupportedChipset(chipset))
+    }
+    
+    public func erase<FlashCartridge: CartKit.FlashCartridge>(chipset: FlashCartridge.Type) -> Result<(), Error> where FlashCartridge.Platform == GameboyClassic {
+        return self
+            .resetFlashModeResult(chipset)
+            .flatMap { _ in self.flushBuffer(for: chipset.Platform.self) }
+            .flatMap { _ in self.sendEraseFlashProgramResult(chipset) }
+            .flatMap { _ in
+                self.read(platform: chipset.Platform.self
+                    , byteCount: 1
+                    , startingAt: 0x0000
+                    , timeout: 30
+                    , responseEvaluator: {
+                        guard $0!.starts(with: [0xFF]) else {
+                            self.continue()
+                            return false
+                        }
+                        return true
+                })
+            }
+            .flatMap { _ in self.resetFlashModeResult(chipset) }
+            .map { _ in () }
     }
 
-    private func restoreResult(_ data: Data, _ update: @escaping ProgressCallback) -> Result<(), Error> {
-        return self
-            .headerResult()
-            .flatMap { header in
-                var progress: Progress!
+    public func write<FlashCartridge: CartKit.FlashCartridge>(to flashCartridge: FlashCartridge, progress: @escaping (Double) -> ()) -> Result<(), Error> {
+        return .failure(CartridgeFlashError.unsupportedChipset(type(of: flashCartridge)))
+    }
+    
+    public func write(to flashCartridge: AM29F016B, progress update: @escaping (Double) -> ()) -> Result<(), Error> {
+        return self.erase(chipset: AM29F016B.self)
+            .flatMap { self.flushBuffer(for: AM29F016B.Platform.self).map { _ in } }
+            .flatMap { self.sendWriteFlashProgram(for: AM29F016B.self) }
+            .map     { Progress(totalUnitCount: Int64(flashCartridge.count)) }
+            .flatMap { progress in
                 //--------------------------------------------------------------
-                switch Platform.self {
-                case is GameboyClassic.Type: progress = Progress(totalUnitCount: Int64((header as! GameboyClassic.Header).ramSize))
-                case is GameboyAdvance.Type: progress = Progress(totalUnitCount: Int64((self as! insideGadgetsController<GameboyAdvance>).ramSize()))
-                default:
-                    return .failure(CartridgeControllerError.platformNotSupported(Platform.self))
-                }
                 let observer = progress.observe(\.fractionCompleted, options: [.new]) { _, change in
                     DispatchQueue.main.sync {
                         update(change.newValue ?? 0)
@@ -215,30 +288,14 @@ extension insideGadgetsController {
                 //--------------------------------------------------------------
                 defer { observer.invalidate() }
                 //--------------------------------------------------------------
-                switch Platform.self {
-                case is GameboyClassic.Type:
-                    return (self as! insideGadgetsController<GameboyClassic>)
-                        .writeSaveResult(data, updating: progress, header: header as! GameboyClassic.Header)
-                default:
-                    return .failure(CartridgeControllerError.platformNotSupported(Platform.self))
-                }
+                return self.flash(flashCartridge, progress: progress)
         }
     }
-    
-    private func deleteResult(_ update: @escaping ProgressCallback) -> Result<(), Error> {
-        return self
-            .headerResult()
-            .flatMap {
-                switch Platform.self {
-                case is GameboyClassic.Type: return .success(Data(count: ($0 as! GameboyClassic.Header).ramSize))
-                case is GameboyAdvance.Type: return .success(Data(count: (self as! insideGadgetsController<GameboyAdvance>).ramSize()))
-                default: return .failure(CartridgeControllerError.platformNotSupported(Platform.self))
-                }
-            }
-            .flatMap { self.restoreResult($0, update) }
-    }
-    
-    public func read<Number>(byteCount: Number, startingAt address: Platform.AddressSpace, timeout: TimeInterval = -1.0, prepare: (() -> ())? = nil, progress update: @escaping (Progress) -> () = { _ in }, responseEvaluator: @escaping ORSSerialPacketEvaluator = { _ in true }) -> Result<Data, Error> where Number: FixedWidthInteger {
+}
+
+//MARK: - insideGadgetsController (Shared) -
+extension insideGadgetsController {
+    fileprivate func read<Platform: Gibby.Platform, Number>(platform: Platform.Type, byteCount: Number, startingAt address: Platform.AddressSpace, timeout: TimeInterval = -1.0, prepare: (() -> ())? = nil, progress update: @escaping (Progress) -> () = { _ in }, responseEvaluator: @escaping ORSSerialPacketEvaluator = { _ in true }) -> Result<Data, Error> where Number: FixedWidthInteger {
         precondition(Thread.current != .main)
         return Result {
             let data = try await {
@@ -249,12 +306,12 @@ extension insideGadgetsController {
                         self.stop()
                         prepare?()
                         self.go(to: address)
-                        self.read()
-                    }
+                        self.read(platform)
+                }
                     , progress: { _, progress in
                         update(progress)
                         self.continue()
-                    }
+                }
                     , responseEvaluator: responseEvaluator
                     , result: $0)
                     .start()
@@ -264,87 +321,63 @@ extension insideGadgetsController {
         }
     }
     
-    public func sendAndWait(_ block: @escaping () -> (), responseEvaluator: @escaping ORSSerialPacketEvaluator = { _ in true }) -> Result<Data, Error> {
-        precondition(Thread.current != .main)
-        return Result { try await
-            {
-                self.request(totalBytes: 1
-                    , packetSize: 1
-                    , prepare: { _ in block() }
-                    , progress: { _, _ in }
-                    , responseEvaluator: responseEvaluator
-                    , result: $0)
-                .start()
-            }
+    fileprivate func flushBuffer<Platform: Gibby.Platform>(for platform: Platform.Type, byteCount: Int = 64, startingAt address: Platform.AddressSpace = 0) -> Result<Data, Error> {
+        return self.read(platform: platform, byteCount: byteCount, startingAt: address)
+    }
+    
+    @discardableResult
+    fileprivate func `continue`() -> Bool {
+        return send("1".bytes())
+    }
+    
+    @discardableResult
+    fileprivate func stop(timeout: UInt32 = 0) -> Bool {
+        return send("0".bytes(), timeout: timeout)
+    }
+    
+    @discardableResult
+    fileprivate func read<Platform: Gibby.Platform>(_ platform: Platform.Type) -> Bool {
+        switch platform {
+        case is GameboyClassic.Type: return send("R".bytes())
+        case is GameboyAdvance.Type: return send("r".bytes())
+        default: return false
         }
     }
     
-    public func scanHeader(_ result: @escaping (Result<Platform.Header, Error>) -> ()) {
-        self.queue.addOperation(BlockOperation {
-            result(self.headerResult())
-        })
+    @discardableResult
+    fileprivate func go<AddressSpace>(to address: AddressSpace, timeout: UInt32 = 250) -> Bool where AddressSpace: FixedWidthInteger {
+        return send("A", number: address, timeout: timeout)
     }
     
-    public func readCartridge(progress: @escaping ProgressCallback, _ result: @escaping (Result<Platform.Cartridge, Error>) -> ()) {
-        self.queue.addOperation(BlockOperation {
-            result(self.cartridgeResult(progress))
-        })
-    }
-    
-    public func backupSave(progress: @escaping ProgressCallback, _ result: @escaping (Result<Data, Error>) -> ()) {
-        self.queue.addOperation(BlockOperation {
-            result(self.backupResult(progress))
-        })
-    }
-    
-    public func restoreSave(data: Data, progress: @escaping ProgressCallback, _ result: @escaping (Result<(), Error>) -> ()) {
-        self.queue.addOperation(BlockOperation {
-            result(self.restoreResult(data, progress))
-        })
-    }
-    
-    public func deleteSave(progress: @escaping ProgressCallback, _ result: @escaping (Result<(), Error>) -> ()) {
-        self.queue.addOperation(BlockOperation {
-            result(self.deleteResult(progress))
-        })
+    fileprivate func verify<Platform: Gibby.Platform>(platform: Platform.Type) -> Result<Platform.Type, Error> {
+        switch platform {
+        case is GameboyClassic.Type: return .success(platform)
+        case is GameboyAdvance.Type: return .success(platform)
+        default: return .failure(CartridgeControllerError.platformNotSupported(platform))
+        }
     }
 }
 
-extension insideGadgetsController where Platform == GameboyAdvance {
+//MARK: - insideGadgetsController (Platform: GameboyClassic) -
+extension insideGadgetsController {
     @discardableResult
-    fileprivate func romSize() -> Int {
-        return 0
-    }
-    
-    @discardableResult
-    fileprivate func ramSize() -> Int {
-        return 0
-    }
-    
-    fileprivate func writeFlashResult<FlashCartridge: CartKit.FlashCartridge>(_ flashCartridge: FlashCartridge, updating progress: Progress) -> Result<(), Error> {
-        return .failure(CartridgeControllerError.platformNotSupported(Platform.self))
-    }
-}
-
-extension insideGadgetsController where Platform == GameboyClassic {
-    @discardableResult
-    fileprivate func toggleRAM(on enabled: Bool, timeout: UInt32 = 250) -> Bool {
-        return set(bank: enabled ? 0x0A : 0x00, at: 0, timeout: timeout)
-    }
-    
-    @discardableResult
-    fileprivate func set<Number>(bank: Number, at address: Platform.AddressSpace, timeout: UInt32 = 250) -> Bool where Number : FixedWidthInteger {
+    private func set<Number>(bank: Number, at address: Number, timeout: UInt32 = 250) -> Bool where Number: FixedWidthInteger {
         return ( send("B", number: address, radix: 16, timeout: timeout)
             &&   send("B", number:    bank, radix: 10, timeout: timeout))
     }
     
     @discardableResult
-    private func mbc2(fix header: Platform.Header) -> Bool {
+    private func toggleRAM(on enabled: Bool, timeout: UInt32 = 250) -> Bool {
+        return set(bank: enabled ? 0x0A : 0x00, at: 0, timeout: timeout)
+    }
+    
+    @discardableResult
+    fileprivate func mbc2(fix header: GameboyClassic.Header) -> Bool {
         switch header.configuration {
         case .two:
             return (
                 self.go(to: 0x0)
-                    && self.read()
+                    && self.read(GameboyClassic.self)
                     && self.stop()
             )
         default:
@@ -353,167 +386,17 @@ extension insideGadgetsController where Platform == GameboyClassic {
     }
     
     @discardableResult
-    private func send(saveData data: Data) -> Bool {
+    fileprivate func send(saveData data: Data) -> Bool {
         return send("W".data(using: .ascii)! + data)
-    }
-    
-    fileprivate func romDataResult(updating progress: Progress, header: Platform.Header) -> Result<Data, Error> {
-        return Result {
-            var romData = Data()
-            for bank in 0..<header.romBanks {
-                progress.becomeCurrent(withPendingUnitCount: Int64(header.romBankSize))
-                //--------------------------------------------------------------
-                let bankData = try self.read(byteCount: header.romBankSize
-                    , startingAt: bank > 0 ? 0x4000 : 0x0000
-                    , prepare: {
-                        self.mbc2(fix: header)
-                        //------------------------------------------------------
-                        guard bank > 0 else { return }
-                        //------------------------------------------------------
-                        if case .one = header.configuration {
-                            self.set(bank:           0, at: 0x6000)
-                            self.set(bank:   bank >> 5, at: 0x4000)
-                            self.set(bank: bank & 0x1F, at: 0x2000)
-                        }
-                        else {
-                            self.set(bank: bank, at: 0x2100)
-                            if bank > 0x100 {
-                                self.set(bank: 1, at: 0x3000)
-                            }
-                        }
-                }).get()
-                //--------------------------------------------------------------
-                romData.append(bankData)
-                //--------------------------------------------------------------
-                progress.resignCurrent()
-            }
-            return romData
-        }
-    }
-    
-    fileprivate func ramDataResult(updating progress: Progress, header: Platform.Header) -> Result<Data, Error> {
-        return Result {
-            let ramBankSize = Int64(header.ramBankSize)
-            var backupData = Data()
-            for bank in 0..<header.ramBanks {
-                progress.becomeCurrent(withPendingUnitCount: ramBankSize)
-                //--------------------------------------------------------------
-                let bankData = try self.read(byteCount: ramBankSize
-                    , startingAt: 0xA000
-                    , prepare: {
-                        self.mbc2(fix: header)
-                        //--------------------------------------------------
-                        // SET: the 'RAM' mode (MBC1-ONLY)
-                        //--------------------------------------------------
-                        if case .one = header.configuration {
-                            self.set(bank: 1, at: 0x6000)
-                        }
-                        //--------------------------------------------------
-                        self.toggleRAM(on: true)
-                        self.set(bank: bank, at: 0x4000)
-                }).get()
-                //--------------------------------------------------------------
-                backupData.append(bankData)
-                //--------------------------------------------------------------
-                progress.resignCurrent()
-            }
-            return backupData
-        }
-    }
-    
-    fileprivate func writeSaveResult(_ data: Data, updating progress: Progress, header: Platform.Header) -> Result<(), Error> {
-        return Result {
-            for bank in 0..<header.ramBanks {
-                let startIndex = bank * header.ramBankSize
-                let endIndex   = startIndex.advanced(by: header.ramBankSize)
-                //--------------------------------------------------------------
-                let slice  = data[startIndex..<endIndex]
-                let ramBankSize = Int64(slice.count)
-                //--------------------------------------------------------------
-                progress.becomeCurrent(withPendingUnitCount: ramBankSize)
-                //--------------------------------------------------------------
-                _ = try await {
-                    self.request(totalBytes: ramBankSize / 64
-                        , packetSize: 1
-                        , prepare: { _ in
-                            if bank == 0 { self.toggleRAM(on: true) }
-                            //--------------------------------------------------
-                            self.stop()
-                            self.mbc2(fix: header)
-                            //--------------------------------------------------
-                            // SET: the 'RAM' mode (MBC1-ONLY)
-                            //--------------------------------------------------
-                            if case .one = header.configuration {
-                                self.set(bank: 1, at: 0x6000)
-                            }
-                            //--------------------------------------------------
-                            self.set(bank: bank, at: 0x4000)
-                            self.go(to: 0xA000)
-                            self.send(saveData: slice[slice.startIndex..<slice.startIndex.advanced(by: 64)])
-                        }
-                        , progress: { _, progress in
-                            let startAddress = Int(progress.completedUnitCount * 64).advanced(by: slice.startIndex)
-                            let rangeOfBytes = startAddress..<Int(startAddress + 64)
-                            self.send(saveData: slice[rangeOfBytes])
-                        }
-                        , responseEvaluator: { _ in true }
-                        , result: $0)
-                        .start()
-                }
-                //--------------------------------------------------------------
-                progress.resignCurrent()
-            }
-        }
-    }
-    
-    fileprivate func writeFlashResult<FlashCartridge: CartKit.FlashCartridge>(_ flashCartridge: FlashCartridge, updating progress: Progress) -> Result<(), Error> {
-        return Result {
-            let header = flashCartridge.header as! Platform.Header
-            for bank in 0..<header.romBanks {
-                let startIndex = FlashCartridge.Index(bank * header.romBankSize)
-                let endIndex   = FlashCartridge.Index(startIndex.advanced(by: header.romBankSize))
-                //--------------------------------------------------------------
-                let slice  = flashCartridge[startIndex..<endIndex]
-                let romBankSize = Int64(slice.count)
-                //--------------------------------------------------------------
-                progress.becomeCurrent(withPendingUnitCount: romBankSize)
-                //--------------------------------------------------------------
-                _ = try await {
-                    self.request(totalBytes: (slice.count / 64)
-                        , packetSize: 1
-                        , prepare: { _ in
-                            self.stop()
-                            self.set(bank: bank, at: 0x2100)
-                            self.go(to: bank > 0 ? 0x4000 : 0x0000)
-                            
-                            let startAddress = slice.startIndex
-                            let bytesInRange = startAddress..<FlashCartridge.Index(startAddress + 64)
-                            let bytesToWrite = "T".data(using: .ascii)! + Data(slice[bytesInRange])
-                            
-                            self.send(bytesToWrite)
-                        }
-                        , progress: { _, progress in
-                            let startAddress = FlashCartridge.Index(progress.completedUnitCount * 64).advanced(by: Int(slice.startIndex))
-                            let bytesInRange = startAddress..<FlashCartridge.Index(startAddress + 64)
-                            let bytesToWrite = "T".data(using: .ascii)! + Data(slice[bytesInRange])
-                            self.send(bytesToWrite)
-                        }
-                        , responseEvaluator: { _ in true }
-                        , result: $0)
-                        .start()
-                }
-                //--------------------------------------------------------------
-                progress.resignCurrent()
-            }
-        }
     }
 }
 
+//MARK: - insideGadgetsController (Write/Erase) -
 extension insideGadgetsController {
     @discardableResult
-    private func flash<Number>(byte: Number, at address: Platform.AddressSpace, timeout: UInt32 = 250) -> Bool where Number : FixedWidthInteger {
+    private func flash(byte: Int, at address: Int, timeout: UInt32 = 250) -> Bool {
         return ( send("F", number: address)
-            &&   send("", number: byte)
+            && send("", number: byte )
         )
     }
     
@@ -526,81 +409,26 @@ extension insideGadgetsController {
     private func pin(mode: String) -> Bool {
         return (
             send("P".bytes())
-         && send(mode.bytes())
+                && send(mode.bytes())
         )
     }
-
-    fileprivate func resetFlashModeResult<FlashCartridge: CartKit.FlashCartridge>(_ chipset: FlashCartridge.Type) -> Result<(), Error> {
-        switch chipset {
-        case is AM29F016B.Type:
-            return self
-                .sendAndWait({ self.flash(byte: 0xF0, at: 0x00) }) { $0!.starts(with: [0x31]) }
-                .map { _ in () }
-        default:
-            return .failure(CartridgeFlashError.unsupportedChipset(chipset))
-        }
-    }
     
-    private func sendWriteFlashProgramResult<FlashCartridge: CartKit.FlashCartridge>(_ chipset: FlashCartridge.Type) -> Result<(), Error> {
-        switch chipset {
-        case is AM29F016B.Type:
-            let hexCodes = [ // '555'
-                (0x555, 0xAA)
-             ,  (0x2AA, 0x55)
-             ,  (0x555, 0xA0)
-            ]
-            return self
-                .sendAndWait({
-                    self.romMode()
-                    self.pin(mode: "W")
-                    self.send("E".bytes())
-                    self.send("", number: hexCodes[0].0)
-                })
-                .flatMap { _ in self.sendAndWait({ self.send("", number: hexCodes[0].1) }, responseEvaluator: { $0!.starts(with: [0x31]) }) }
-                .flatMap { _ in self.sendAndWait({ self.send("", number: hexCodes[1].0) }, responseEvaluator: { $0!.starts(with: [0x31]) }) }
-                .flatMap { _ in self.sendAndWait({ self.send("", number: hexCodes[1].1) }, responseEvaluator: { $0!.starts(with: [0x31]) }) }
-                .flatMap { _ in self.sendAndWait({ self.send("", number: hexCodes[2].0) }, responseEvaluator: { $0!.starts(with: [0x31]) }) }
-                .flatMap { _ in self.sendAndWait({ self.send("", number: hexCodes[2].1) }, responseEvaluator: { $0!.starts(with: [0x31]) }) }
-                .map { _ in () }
-        default:
-            return .failure(CartridgeFlashError.unsupportedChipset(chipset))
-        }
-    }
-
-    private func flashDataResult<FlashCartridge: CartKit.FlashCartridge>(_ flashCartridge: FlashCartridge, _ update: @escaping ProgressCallback) -> Result<(), Error> {
-        let platform = type(of: flashCartridge).Platform.self
-        var progress = Progress(totalUnitCount: Int64(flashCartridge.count))
-        //--------------------------------------------------------------
-        let observer = progress.observe(\.fractionCompleted, options: [.new]) { _, change in
-            DispatchQueue.main.sync {
-                update(change.newValue ?? 0)
+    fileprivate func sendAndWait(_ block: @escaping () -> (), responseEvaluator: @escaping ORSSerialPacketEvaluator = { _ in true }) -> Result<Data, Error> {
+        precondition(Thread.current != .main)
+        return Result { try await
+            {
+                self.request(totalBytes: 1
+                    , packetSize: 1
+                    , prepare: { _ in block() }
+                    , progress: { _, _ in }
+                    , responseEvaluator: responseEvaluator
+                    , result: $0)
+                    .start()
             }
         }
-        //--------------------------------------------------------------
-        defer { observer.invalidate() }
-        //--------------------------------------------------------------
-        switch platform {
-        case is GameboyClassic.Type:
-            return (self as! insideGadgetsController<GameboyClassic>)
-                .writeFlashResult(flashCartridge, updating: progress)
-        default:
-            return .failure(CartridgeControllerError.platformNotSupported(platform))
-        }
     }
     
-    public func write<FlashCartridge: CartKit.FlashCartridge>(_ flashCartridge: FlashCartridge, progress: @escaping ProgressCallback, _ result: @escaping ((Result<(), Error>) -> ())) {
-        self.queue.addOperation(BlockOperation {
-            result(self.eraseResult(type(of: flashCartridge))
-                .flatMap { self.flushBufferResult().map { _ in } }
-                .flatMap { self.sendWriteFlashProgramResult(type(of: flashCartridge)) }
-                .flatMap { self.flashDataResult(flashCartridge, progress) }
-            )
-        })
-    }
-}
-
-extension insideGadgetsController {
-    private func sendEraseFlashProgramResult<FlashCartridge: CartKit.FlashCartridge>(_ chipset: FlashCartridge.Type) -> Result<(), Error> {
+    fileprivate func sendEraseFlashProgramResult<FlashCartridge: CartKit.FlashCartridge>(_ chipset: FlashCartridge.Type) -> Result<(), Error> {
         switch chipset {
         case is AM29F016B.Type:
             return self
@@ -620,57 +448,86 @@ extension insideGadgetsController {
         }
     }
     
-    private func flushBufferResult(_ byteCount: Int = 64, startingAt address: Platform.AddressSpace = 0) -> Result<Data, Error> {
-        return self.read(byteCount: byteCount, startingAt: address)
-    }
-    
-    fileprivate func eraseResult<FlashCartridge: CartKit.FlashCartridge>(_ chipset: FlashCartridge.Type) -> Result<(), Error> {
-        return self
-            .resetFlashModeResult(chipset)
-            .flatMap { self.flushBufferResult() }
-            .flatMap { _ in self.sendEraseFlashProgramResult(chipset) }
-            .flatMap { _ in
-                self.read(byteCount: 1
-                    , startingAt: 0x0000
-                    , timeout: 30
-                    , responseEvaluator: {
-                        guard $0!.starts(with: [0xFF]) else {
-                            self.continue()
-                            return false
-                        }
-                        return true
-                })
-            }
-            .flatMap { _ in self.resetFlashModeResult(chipset) }
-            .map { _ in () }
-    }
-
-    public func erase<FlashCartridge: CartKit.FlashCartridge>(_ chipset: FlashCartridge.Type, _ result: @escaping (Result<(), Error>) -> ()) {
-        return result(.failure(CartridgeFlashError.unsupportedChipset(chipset)))
-    }
-    
-    public func erase(_ chipset: AM29F016B.Type, _ result: @escaping (Result<(), Error>) -> ()) {
-        self.queue.addOperation(BlockOperation {
-            result(self.eraseResult(chipset))
-        })
-    }
-}
-
-extension insideGadgetsController {
-    private func determineFlashCartResult(bitFlipped: Bool = true) -> Result<String, Error> {
-        return self
-            .sendAndWait({ self.flash(byte: bitFlipped ? 0xAA : 0xA9, at: 0xAAA) })
-            .flatMap { _ in self.sendAndWait({ self.flash(byte: 0x55, at: 0x555) }) }
-            .flatMap { _ in self.sendAndWait({ self.flash(byte: 0x90, at: 0xAAA) }) }
-            .flatMap { _ in self.flushBufferResult().map { $0.hexString() } }
-            .flatMap { description in
-                self.sendAndWait({ self.flash(byte: 0xF0, at: 0x00) }).map { _ in description }
+    fileprivate func resetFlashModeResult<FlashCartridge: CartKit.FlashCartridge>(_ chipset: FlashCartridge.Type) -> Result<(), Error> {
+        switch chipset {
+        case is AM29F016B.Type:
+            return self
+                .sendAndWait({ self.flash(byte: 0xF0, at: 0x00) }) { $0!.starts(with: [0x31]) }
+                .map { _ in () }
+        default:
+            return .failure(CartridgeFlashError.unsupportedChipset(chipset))
         }
     }
     
-    public func flashCartDescription(_ result: @escaping (Result<String, Error>) -> ()) {
-        self.queue.addOperation(BlockOperation {
-            result(self.determineFlashCartResult())
-        })
+    fileprivate func sendWriteFlashProgram<FlashCartridge: CartKit.FlashCartridge>(for chipset: FlashCartridge.Type) -> Result<(), Error> {
+        switch chipset {
+        case is AM29F016B.Type:
+            let hexCodes = [ // '555'
+                (0x555, 0xAA)
+                ,  (0x2AA, 0x55)
+                ,  (0x555, 0xA0)
+            ]
+            return self
+                .sendAndWait({
+                    self.romMode()
+                    self.pin(mode: "W")
+                    self.send("E".bytes())
+                    self.send("", number: hexCodes[0].0)
+                })
+                .flatMap { _ in self.sendAndWait({ self.send("", number: hexCodes[0].1) }, responseEvaluator: { $0!.starts(with: [0x31]) }) }
+                .flatMap { _ in self.sendAndWait({ self.send("", number: hexCodes[1].0) }, responseEvaluator: { $0!.starts(with: [0x31]) }) }
+                .flatMap { _ in self.sendAndWait({ self.send("", number: hexCodes[1].1) }, responseEvaluator: { $0!.starts(with: [0x31]) }) }
+                .flatMap { _ in self.sendAndWait({ self.send("", number: hexCodes[2].0) }, responseEvaluator: { $0!.starts(with: [0x31]) }) }
+                .flatMap { _ in self.sendAndWait({ self.send("", number: hexCodes[2].1) }, responseEvaluator: { $0!.starts(with: [0x31]) }) }
+                .map { _ in () }
+        default:
+            return .failure(CartridgeFlashError.unsupportedChipset(chipset))
+        }
+    }
+    
+}
+
+//MARK: - insideGadgetsController (Flash Chipset) -
+extension insideGadgetsController {
+    fileprivate func flash(_ flashCartridge: AM29F016B, progress: Progress) -> Result<(), Error> {
+        return Result {
+            let header = flashCartridge.header
+            for bank in 0..<header.romBanks {
+                let startIndex = bank * header.romBankSize
+                let endIndex   = startIndex.advanced(by: header.romBankSize)
+                //--------------------------------------------------------------
+                let slice  = flashCartridge[startIndex..<endIndex]
+                let romBankSize = Int64(slice.count)
+                //--------------------------------------------------------------
+                progress.becomeCurrent(withPendingUnitCount: romBankSize)
+                //--------------------------------------------------------------
+                _ = try await {
+                    self.request(totalBytes: (slice.count / 64)
+                        , packetSize: 1
+                        , prepare: { _ in
+                            self.stop()
+                            self.set(bank: bank, at: 0x2100)
+                            self.go(to: bank > 0 ? 0x4000 : 0x0000)
+                            
+                            let startAddress = slice.startIndex
+                            let bytesInRange = startAddress..<(startAddress + 64)
+                            let bytesToWrite = "T".data(using: .ascii)! + Data(slice[bytesInRange])
+                            
+                            self.send(bytesToWrite)
+                    }
+                        , progress: { _, progress in
+                            let startAddress = Int((progress.completedUnitCount * 64).advanced(by: Int(slice.startIndex)))
+                            let bytesInRange = startAddress..<(startAddress + 64)
+                            let bytesToWrite = "T".data(using: .ascii)! + Data(slice[bytesInRange])
+                            self.send(bytesToWrite)
+                    }
+                        , responseEvaluator: { _ in true }
+                        , result: $0)
+                        .start()
+                }
+                //--------------------------------------------------------------
+                progress.resignCurrent()
+            }
+        }
     }
 }

--- a/CartKit/Source/Devices/insideGadgets/insideGadgetsMiniController.swift
+++ b/CartKit/Source/Devices/insideGadgets/insideGadgetsMiniController.swift
@@ -1,4 +1,4 @@
 import Gibby
 
-public final class insideGadgetsMiniController: insideGadgetsController<GameboyClassic> {
-}
+// public class insideGadgetsMiniController: insideGadgetsController<GameboyClassic> {
+// }

--- a/CartKit/Source/Devices/insideGadgets/insideGadgetsMiniController.swift
+++ b/CartKit/Source/Devices/insideGadgets/insideGadgetsMiniController.swift
@@ -1,4 +1,0 @@
-import Gibby
-
-// public class insideGadgetsMiniController: insideGadgetsController<GameboyClassic> {
-// }

--- a/CartKit/Source/Operations/SerialPortRequest.swift
+++ b/CartKit/Source/Operations/SerialPortRequest.swift
@@ -41,14 +41,10 @@ class SerialPortRequest<Controller: SerialPortController>: OpenPortOperation<Con
                     let upToCount = self.isCancelled ? 0 : self.progress.totalUnitCount
                     let data      = self.response.prefix(upTo: Int(upToCount))
                     self.result   = .success(data)
-                    DispatchQueue.main.async {
-                        self.complete()
-                    }
+                    self.complete()
                 }
                 else {
-                    DispatchQueue.main.async {
-                        self.perform(self.progress)
-                    }
+                    self.perform(self.progress)
                 }
             }
         }
@@ -105,9 +101,7 @@ class SerialPortRequest<Controller: SerialPortController>: OpenPortOperation<Con
         
         self.queue.asyncAfter(deadline: deadline) { [weak self] in
             if self?.isExecuting == true {
-                DispatchQueue.main.async {
-                    self?.timedOut()
-                }
+                self?.timedOut()
             }
         }
         self.perform(self.progress)

--- a/CartKit/Source/Serial Port/ThreadSafeSerialPortController.swift
+++ b/CartKit/Source/Serial Port/ThreadSafeSerialPortController.swift
@@ -34,7 +34,6 @@ open class ThreadSafeSerialPortController: NSObject, SerialPortController {
     /**
      */
     public final func openReader(delegate: ORSSerialPortDelegate?) {
-        precondition(Thread.current != .main)
         self.isOpenCondition.whileLocked {
             while self.currentDelegate != nil {
                 self.isOpenCondition.wait()
@@ -42,10 +41,8 @@ open class ThreadSafeSerialPortController: NSObject, SerialPortController {
             //------------------------------------------------------------------
             self.delegate = delegate
             //------------------------------------------------------------------
-            DispatchQueue.main.sync {
-                if self.reader.isOpen == false {
-                    self.open()
-                }
+            if self.reader.isOpen == false {
+                self.open()
             }
         }
     }


### PR DESCRIPTION
### Description
I didn't like the way things were going with `ContextViewController`, so I opted to move remove the callback-based APIs in `CartridgeController` and have them return `Result` instead. This also had the effect of adding a `static` `perform` function that will get called on its own queue.

### What does this do?
All of the callback APIs have been changed to return `Result` type. In practice, developers should use the `perform` method to materialize the values needed. 

Here's an example of how this works is:
```swift
// Perform passes in a Result, materializing an instance of controller upon success
insideGadgetsController.perform { controller in
    switch controller.flatMap({ $0.header(for: GameboyClassic.self) }) {
    case .success(let header): print(header)
    case .failure(let error): (/* handle error */)
    }
}
```

### How to test
All tests inside `CartridgeTests.swift` have been updated. View this file to better understand how to use the new `perform` block.

### Known Issues
The project's documentation still needs to be updated. I plan on included examples in the `README.md` in the near future.