### PR TITLE
[CartBoy] alpha bump: '2' -> '3'

### DIFF
--- a/CartBoy/CartBoy/Info.plist
+++ b/CartBoy/CartBoy/Info.plist
@@ -88,7 +88,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSMainStoryboardFile</key>


### PR DESCRIPTION
Version bump to `1.0.3-alpha`.
---
#### Changes / Fixes
- [Gibby-PR#2](https://github.com/KevinVitale/Gibby/pull/2)
> _"Add RAM and battery descriptors for Pocket Camera cartridges"_