### PR TITLE
Updates GUI to use `SerialDeviceSession`

### DIFF
--- a/CartKit/CartKit.xcodeproj/project.pbxproj
+++ b/CartKit/CartKit.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0A163B282249B6EB00D41873 /* CartridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A163B272249B6EB00D41873 /* CartridgeTests.swift */; };
 		0A30B83423B125C8007B7154 /* SerialDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A30B83323B125C8007B7154 /* SerialDevice.swift */; };
 		0A30B83A23B1336A007B7154 /* GBxCart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A30B83923B1336A007B7154 /* GBxCart.swift */; };
+		0A32C6BF23E8BE8D00094175 /* FlashCartridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A32C6BE23E8BE8D00094175 /* FlashCartridge.swift */; };
 		0A58A73223B6C6AD00D90347 /* DeviceProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A58A73123B6C6AD00D90347 /* DeviceProfile.swift */; };
 		0A61C76522371701001D653D /* SerialPortController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A61C76422371701001D653D /* SerialPortController.swift */; };
 		0A67DE6521F4CCC0009CA98F /* ORSSerialPort+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A67DE6421F4CCC0009CA98F /* ORSSerialPort+Ext.swift */; };
@@ -69,6 +70,7 @@
 		0A163B272249B6EB00D41873 /* CartridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartridgeTests.swift; sourceTree = "<group>"; };
 		0A30B83323B125C8007B7154 /* SerialDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerialDevice.swift; sourceTree = "<group>"; };
 		0A30B83923B1336A007B7154 /* GBxCart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBxCart.swift; sourceTree = "<group>"; };
+		0A32C6BE23E8BE8D00094175 /* FlashCartridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashCartridge.swift; sourceTree = "<group>"; };
 		0A3DD4D021F2A64800BCC6D4 /* ORSSerial.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ORSSerial.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0A58A73123B6C6AD00D90347 /* DeviceProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceProfile.swift; sourceTree = "<group>"; };
 		0A61C76422371701001D653D /* SerialPortController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerialPortController.swift; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 				0ADE2860224846FE00BD4E6A /* AM29F016B.swift */,
 				0A11DB6122127E1600C7DD13 /* Data+Ext.swift */,
 				0A58A73123B6C6AD00D90347 /* DeviceProfile.swift */,
+				0A32C6BE23E8BE8D00094175 /* FlashCartridge.swift */,
 				0A30B83923B1336A007B7154 /* GBxCart.swift */,
 				0AD9F40B23E0B4C100F4D606 /* GBxCart+Result.swift */,
 				0AE7F26F221D942A00D86827 /* NSCondition+Ext.swift */,
@@ -348,6 +351,7 @@
 			files = (
 				0A58A73223B6C6AD00D90347 /* DeviceProfile.swift in Sources */,
 				0A61C76522371701001D653D /* SerialPortController.swift in Sources */,
+				0A32C6BF23E8BE8D00094175 /* FlashCartridge.swift in Sources */,
 				0A30B83A23B1336A007B7154 /* GBxCart.swift in Sources */,
 				0A0DF2B2225AC07B002278BE /* SerialPortRequest.swift in Sources */,
 				0AC59C562234A5180040BAA4 /* OpenPortOperation.swift in Sources */,

--- a/CartKit/Source/Data+Ext.swift
+++ b/CartKit/Source/Data+Ext.swift
@@ -36,7 +36,7 @@ extension BinaryInteger {
 }
 
 extension String {
-    func bytes(using encoding: String.Encoding = .ascii) -> Data? {
+    public func bytes(using encoding: String.Encoding = .ascii) -> Data? {
         guard let data = self.data(using: encoding) else {
             return nil
         }

--- a/CartKit/Source/FlashCartridge.swift
+++ b/CartKit/Source/FlashCartridge.swift
@@ -1,0 +1,143 @@
+import Gibby
+
+public protocol Chipset {
+    associatedtype Platform: Gibby.Platform
+    
+    static func erase<SerialDevice: SerialPortController>(_ serialDevice: Result<SerialDevice,Swift.Error>) -> Result<SerialDevice,Swift.Error>
+}
+
+public enum ChipsetFlashProgram {
+    case _555
+    case _AAA
+    case _555_BitSwapped
+    case _AAA_BitSwapped
+    case _5555
+    
+    public static let allFlashPrograms: [ChipsetFlashProgram] = [
+        ._555,
+        ._AAA,
+        ._555_BitSwapped,
+        ._AAA_BitSwapped,
+        ._5555,
+    ]
+    
+    internal var addressAndBytes: [(address: UInt16, byte: UInt16)] {
+        switch self {
+        case ._555            :
+            return [
+                (0x555,0xAA),
+                (0x2AA,0x55),
+                (0x555,0x90),
+            ]
+        case ._AAA            :
+            return [
+                (0xAAA,0xAA),
+                (0x555,0x55),
+                (0xAAA,0x90),
+            ]
+        case ._555_BitSwapped :
+            return [
+                (0x555,0xA9),
+                (0x2AA,0x56),
+                (0x555,0x90),
+            ]
+        case ._AAA_BitSwapped :
+            return [
+                (0xAAA,0xA9),
+                (0x555,0x56),
+                (0xAAA,0x90),
+            ]
+        case ._5555           :
+            return [
+                (0x5555,0xAA),
+                (0x2AAA,0x55),
+                (0x5555,0x90),
+            ]
+        }
+    }
+}
+
+extension Result where Success == SerialDevice<GBxCart>, Failure == Swift.Error {
+    public func detectFlashID(using flashProgram: ChipsetFlashProgram) -> Result<Int,Failure> {
+        self.timeout(sending: "0".bytes())
+            .timeout(sending: "G\0".bytes())
+            .timeout(sending: "PW\0".bytes())
+            .flatMap { serialDevice in
+                Result {
+                    try flashProgram.addressAndBytes.forEach { (address, byte) in
+                        let addressString = String(address, radix: 16, uppercase: true)
+                        let byteString    = String(byte, radix: 16, uppercase: true)
+                        let _: Data = try sendAndWait("0F\(addressString)\0\(byteString)\0".bytes()).get()
+                    }
+                    return serialDevice
+                }
+            }
+            .sendAndWait("A0\0R".bytes())
+            .flatMap { data in
+                sendAndWait("0F0\0F0\0".bytes()).map { (_: Data) in
+                    Int(data.hexString(separator: ""), radix: 16) ?? NSNotFound
+                }
+        }
+    }
+}
+
+public struct FlashCartridge<C: Chipset>: Cartridge {
+    public typealias Platform = C.Platform
+    public typealias Index    = Platform.Cartridge.Index
+    
+    public init(bytes: Data) {
+        self.cartridge = .init(bytes: bytes)
+    }
+
+    private let cartridge: Platform.Cartridge
+
+    public subscript(position: Index) -> Data.Element {
+        return cartridge[Index(position)]
+    }
+    
+    public var startIndex: Index {
+        return Index(cartridge.startIndex)
+    }
+    
+    public var endIndex: Index {
+        return Index(cartridge.endIndex)
+    }
+    
+    public func index(after i: Index) -> Index {
+        return Index(cartridge.index(after: i))
+    }
+    
+    public var fileExtension: String {
+        cartridge.fileExtension
+    }
+}
+
+public struct AM29F016B: Chipset {
+    public static func erase<SerialDevice>(_ serialDevice: Result<SerialDevice, Error>) -> Result<SerialDevice, Swift.Error> where SerialDevice: SerialPortController {
+        serialDevice
+            .sendAndWait("0F0\0F0\0".bytes())
+            .timeout(sending:"G".bytes())
+            .timeout(sending:"PW".bytes())
+            .sendAndWait("0F555\0AA\0".bytes())
+            .sendAndWait("0F2AA\055\0".bytes())
+            .sendAndWait("0F555\080\0".bytes())
+            .sendAndWait("0F555\0AA\0".bytes())
+            .sendAndWait("0F2AA\055\0".bytes())
+            .sendAndWait("0F555\010\0".bytes())
+            .sendAndWait("0A0\0R".bytes(),
+                 packetByteSize :64,
+                 isValidPacket  :{ serialDevice, data in
+                    guard data!.starts(with: [0xFF]) else {
+                        serialDevice.send("1".bytes(), timeout: 250)
+                        return false
+                    }
+                    return true
+            })
+            .flatMap { (_: Data) in
+                serialDevice
+            }
+            .sendAndWait("0F0\0F0\0".bytes())
+    }
+    
+    public typealias Platform = GameboyClassic
+}

--- a/CartKit/Source/GBxCart.swift
+++ b/CartKit/Source/GBxCart.swift
@@ -28,14 +28,14 @@ extension ORSSerialPort {
 
 extension SerialDevice where Device == GBxCart {
     func seek<Address: FixedWidthInteger>(toAddress address: Address) {
-        send(.bytes(forCommand: "A", number: address, terminate: true), timeout: 250)
+        send(.bytes(forCommand: "A", number: address), timeout: 250)
     }
     
     @discardableResult
     func setBank<Number>(
-        _ bank         :Number,
-        at address     :Number,
-        timeout        :UInt32 = 250) -> Bool where Number: FixedWidthInteger
+        _ bank     :Number,
+        at address :Number,
+        timeout    :UInt32 = 250) -> Bool where Number: FixedWidthInteger
     {
         return ( send(.bytes(forCommand: "B", number: address, radix: 16), timeout: timeout)
             &&   send(.bytes(forCommand: "B", number:    bank, radix: 10), timeout: timeout))
@@ -51,6 +51,13 @@ extension SerialDevice where Device == GBxCart {
 }
 
 public extension Result where Success == SerialDevice<GBxCart>, Failure == Swift.Error {
+    /**
+     *
+     */
+    func readCartridgeMode() -> Result<UInt8,Failure> {
+        sendAndWait("0C\0".bytes()).map { UInt8($0.hexString()) ?? .min }
+    }
+    
     /**
      *
      */
@@ -73,7 +80,7 @@ public extension Result where Success == SerialDevice<GBxCart>, Failure == Swift
                     serialDevice.seek(toAddress: platform.headerRange.lowerBound)
                     serialDevice.startReading(forPlatform :platform)
                 }
-                else if progress.isFinished || progress.isCancelled {
+                else if progress.isFinished {
                     serialDevice.send("0\0".bytes())
                 }
                 else {

--- a/CartKit/Source/GBxCart.swift
+++ b/CartKit/Source/GBxCart.swift
@@ -65,6 +65,12 @@ public extension Result where Success == SerialDevice<GBxCart>, Failure == Swift
         sendAndWait("h\0".bytes()).map { UInt8($0.hexString()) ?? .min }
     }
     
+    func readVoltage() -> Result<Voltage?,Failure> {
+        sendAndWait("C\0".bytes())
+            .map { UInt8($0.hexString()) ?? .min }
+            .map(Voltage.init)
+    }
+    
     /**
      *
      */

--- a/CartKit/Source/SerialPortController.swift
+++ b/CartKit/Source/SerialPortController.swift
@@ -187,8 +187,21 @@ extension Result where Success: SerialPortController, Failure == Swift.Error {
                     didFinish      :finishCallback
         ).flatMap { (_: Data) in self }
     }
+}
     
+extension Result where Success: SerialPortController, Failure == Swift.Error {
     public func erase<C: Chipset>(flashCartridge chipset: C.Type) -> Result<Success,Failure> {
         C.erase(self)
+    }
+    
+    
+    public func flash<C: Chipset>(cartridge: FlashCartridge<C>, progress update: ((Progress) -> ())? = nil) -> Result<Success,Failure> {
+        C.flash(self, cartridge: cartridge, progress: update)
+    }
+    
+    public func flash<C: Chipset>(cartridge: Result<FlashCartridge<C>,Failure>, progress update: ((Progress) -> ())? = nil) -> Result<Success,Failure> {
+        cartridge.flatMap {
+            C.flash(self, cartridge: $0, progress: update)
+        }
     }
 }

--- a/CartKit/Tests/CartridgeTests.swift
+++ b/CartKit/Tests/CartridgeTests.swift
@@ -4,6 +4,18 @@ import Gibby
 import CartKit
 
 class CartridgeTests: XCTestCase {
+    func testSessionReadAdvanceHeader() {
+        let exp = expectation(description: "")
+        SerialDeviceSession<GBxCart>.open { serialDevice in
+            switch serialDevice.readHeader(forPlatform: GameboyAdvance.self) {
+            case .success(let header): print(header)
+            case .failure(let error):  XCTFail("\(error)")
+            }
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 20)
+    }
+    
     func testSessionReadClassicHeader() {
         let exp = expectation(description: "")
         SerialDeviceSession<GBxCart>.open { serialDevice in
@@ -83,6 +95,61 @@ class CartridgeTests: XCTestCase {
                 .map({ $0.md5 ?? .init() })
             {
             case .success(let results) :print(results.hexString(separator: ""))
+            case .failure(let error)   :XCTFail("\(error)")
+            }
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 300)
+    }
+    
+    func testSessionEraseClassicFlashCartridge() {
+        let exp = expectation(description: "")
+        SerialDeviceSession<GBxCart>.open { serialDevice in
+            switch serialDevice
+                .erase(flashCartridge: AM29F016B.self)
+                .readHeader(forPlatform: GameboyClassic.self)
+            {
+            case .success(let header) :print(header)
+            case .failure(let error)  :XCTFail("\(error)")
+            }
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 300)
+    }
+    
+    
+    func testDetectFlashCartridge() {
+        let exp = expectation(description: "")
+        SerialDeviceSession<GBxCart>.open { serialDevice in
+            ChipsetFlashProgram.allFlashPrograms.forEach {
+                switch serialDevice.detectFlashID(using: $0) {
+                case .success(let flashID) :print("\($0): \(flashID)")
+                case .failure(let error)   :XCTFail("\(error)")
+                }
+            }
+            
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 300)
+    }
+    
+    func testDetectCartridgeMode() {
+        let exp = expectation(description: "")
+        SerialDeviceSession<GBxCart>.open { serialDevice in
+            switch serialDevice.readCartridgeMode() {
+            case .success(let mode)  :print(mode)
+            case .failure(let error) :XCTFail("\(error)")
+            }
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 300)
+    }
+    
+    func testDetectPCBVersion() {
+        let exp = expectation(description: "")
+        SerialDeviceSession<GBxCart>.open { serialDevice in
+            switch serialDevice.readPCBVersion() {
+            case .success(let version) :print(version)
             case .failure(let error)   :XCTFail("\(error)")
             }
             exp.fulfill()

--- a/CartKit/Tests/CartridgeTests.swift
+++ b/CartKit/Tests/CartridgeTests.swift
@@ -117,6 +117,28 @@ class CartridgeTests: XCTestCase {
         waitForExpectations(timeout: 300)
     }
     
+    func testSessionClassicFlashCartridge() {
+        let exp = expectation(description: "")
+        SerialDeviceSession<GBxCart>.open { serialDevice in
+            let openFile = Result {
+                try FlashCartridge<AM29F016B>(filePath: "/Users/kevin/Desktop/POKEMON_SLV.gbc")
+            }
+            switch openFile
+                .flatMap({ cartridge in
+                    serialDevice
+                        .erase(flashCartridge: AM29F016B.self)
+                        .flash(cartridge: cartridge, progress: { print($0.fractionCompleted) })
+                })
+                .readHeader(forPlatform: GameboyClassic.self)
+            {
+            case .success(let header) :print(header)
+            case .failure(let error)  :XCTFail("\(error)")
+            }
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 300)
+    }
+    
     
     func testDetectFlashCartridge() {
         let exp = expectation(description: "")


### PR DESCRIPTION
Have you heard? `SerialDeviceSession` is all the rage!

By using a session, the client code can _open_ a serial device with all the guarantees that the communication being done is on a background queue. More importantly: the APIs for this is much saner than it was before (where a `DispatchQueue` needed to be explicitly created by the client).